### PR TITLE
Implemented category diff and object diff blocks

### DIFF
--- a/Source/Libraries/HedgeModManager.CodeCompiler/CodeFile.cs
+++ b/Source/Libraries/HedgeModManager.CodeCompiler/CodeFile.cs
@@ -82,9 +82,9 @@ public class CodeFile : IIncludeResolver, IEnumerable<CSharpCode>
             // Renamed
             if (Codes.SingleOrDefault(x => x.Body == code.Body) is { } renamed)
             {
-                if (code.Name != renamed.Name)
+                if (code.Name != renamed.Name || code.Category != renamed.Category)
                 {
-                    diff.Renamed($"{GetCodeDiffName(code)} -> {GetCodeDiffName(renamed)}", code.Name, renamed.Name);
+                    diff.Renamed($"{GetCodeDiffName(code)} -> {GetCodeDiffName(renamed)}", code, renamed);
 
                     // Remove this code from the added list so we don't display it twice.
                     if (addedCodes.SingleOrDefault(x => x.Name == renamed.Name) is { } duplicate)

--- a/Source/Libraries/HedgeModManager.Diagnostics/Diff.cs
+++ b/Source/Libraries/HedgeModManager.Diagnostics/Diff.cs
@@ -25,6 +25,12 @@ public class Diff
         mBlocks[(int)type].Add(new DiffBlock(type, description, dataKey, dataValue));
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void MakeBlock(DiffType type, string? description, object dataKey, object dataValue)
+    {
+        mBlocks[(int)type].Add(new DiffBlock(type, description, dataKey, dataValue));
+    }
+
     public void Add(DiffBlock block)
     {
         mBlocks[(int)block.Type].Add(block);
@@ -48,6 +54,11 @@ public class Diff
     public void Renamed(string? description, string oldName, string newName)
     {
         MakeBlock(DiffType.Renamed, description, oldName, newName);
+    }
+
+    public void Renamed(string? description, object oldData, object newData)
+    {
+        MakeBlock(DiffType.Renamed, description, oldData, newData);
     }
 
     public List<DiffBlock> ToList()

--- a/Source/Libraries/HedgeModManager.Diagnostics/DiffBlock.cs
+++ b/Source/Libraries/HedgeModManager.Diagnostics/DiffBlock.cs
@@ -4,7 +4,7 @@ public class DiffBlock
 {
     public DiffType Type { get; set; }
     public string? Description { get; set; }
-    public KeyValuePair<string, string> Data { get; set; }
+    public KeyValuePair<object, object> Data { get; set; }
 
     public DiffBlock(DiffType type, string? description)
     {
@@ -16,13 +16,16 @@ public class DiffBlock
     {
         Type = type;
         Description = description;
-        Data = new KeyValuePair<string, string>(dataKey, string.Empty);
+        Data = new(dataKey, string.Empty);
     }
 
-    public DiffBlock(DiffType type, string? description, string dataKey, string dataValue)
+    public DiffBlock(DiffType type, string? description, object dataKey, object dataValue)
     {
         Type = type;
         Description = description;
-        Data = new KeyValuePair<string, string>(dataKey, dataValue);
+        Data = new(dataKey, dataValue);
     }
+
+    public DiffBlock(DiffType type, string? description, string dataKey, string dataValue)
+        : this(type, description, (object)dataKey, (object)dataValue) { }
 }

--- a/Source/Libraries/HedgeModManager.Diagnostics/DiffBlock.cs
+++ b/Source/Libraries/HedgeModManager.Diagnostics/DiffBlock.cs
@@ -12,19 +12,15 @@ public class DiffBlock
         Description = description;
     }
 
-    public DiffBlock(DiffType type, string? description, string dataKey)
-    {
-        Type = type;
-        Description = description;
-        Data = new(dataKey, string.Empty);
-    }
-
     public DiffBlock(DiffType type, string? description, object dataKey, object dataValue)
     {
         Type = type;
         Description = description;
         Data = new(dataKey, dataValue);
     }
+
+    public DiffBlock(DiffType type, string? description, string dataKey)
+        : this(type, description, dataKey, string.Empty) { }
 
     public DiffBlock(DiffType type, string? description, string dataKey, string dataValue)
         : this(type, description, (object)dataKey, (object)dataValue) { }


### PR DESCRIPTION
This PR allows returning objects in diff blocks, which is required for `Renamed` diff blocks to pass `CSharpCode` objects to the frontend, so both the name and category of the renamed code can be checked when re-enabling renamed codes.

This PR will be followed up in the active HMM repository with a commit to address this change once the NuGet package has been updated.