### PR TITLE
Prase `.desktop` files for UnleashedRecomp

### DIFF
--- a/Source/HedgeModManager/ModdableGameLocator.cs
+++ b/Source/HedgeModManager/ModdableGameLocator.cs
@@ -4,6 +4,7 @@ using HedgeModManager.Epic;
 using HedgeModManager.Properties;
 using Microsoft.Win32;
 using Steam;
+using Text;
 using System.IO;
 using System.Linq;
 
@@ -316,10 +317,15 @@ public class ModdableGameLocator
                         string path = Path.Combine(searchPath, "applications", $"{entry.ID}.desktop");
                         if (File.Exists(path))
                         {
+                            var ini = Ini.FromFile(path);
+                            ini.TryGetValue("Desktop Entry", out var desktopEntry);
+                            var rootPath = desktopEntry.Get<string>("Path", root);
+                            var execPath = desktopEntry.Get<string>("Exec", entry.Executable);
+
                             var gameSimple = new GameSimple(
                                 "Desktop", entry.ID, gameInfo.ID,
-                                root, Path.GetFileName(entry.Executable), "Linux",
-                                "xdg-open", $"{entry.Executable}:");
+                                rootPath, Path.GetFileName(execPath), "Linux",
+                                execPath, $"{entry.Executable}:");
 
                             var game = new ModdableGameGeneric(gameSimple)
                             {


### PR DESCRIPTION
I had issues running the located desktop file for UnleashedRecomp. Running the game through the mod manager leads to opening the browser instead of the game (an issue with `xdg-open`). However, the desktop file for the game works correctly.

In this PR, I tried to parse the content of the desktop file, replacing the root path and executable path. This way, the game starts as expected.