### PR TITLE
Allow `Ctrl+Q` Shortcut to Close

### DIFF
--- a/Source/HedgeModManager.UI/Views/MainWindow.axaml.cs
+++ b/Source/HedgeModManager.UI/Views/MainWindow.axaml.cs
@@ -98,6 +98,7 @@ public partial class MainWindow : Window
         bool toggleFullscreen = e.KeyModifiers == KeyModifiers.Alt && e.Key == Key.Enter;
         bool isShift = e.KeyModifiers.HasFlag(KeyModifiers.Shift);
         bool isAlt = e.KeyModifiers.HasFlag(KeyModifiers.Alt);
+        bool isQuit = e.KeyModifiers == KeyModifiers.Control && e.Key == Key.Q;
         if (ViewModel == null)
             return;
 
@@ -216,6 +217,10 @@ public partial class MainWindow : Window
             else
                 ViewModel.WindowState = WindowState.FullScreen;
             ViewModel.Config.LastWindowState = ViewModel.WindowState;
+        }
+        else if (isQuit)
+        {
+            Close();
         }
     }
 


### PR DESCRIPTION
Added the ability to use `Ctrl+Q` to quit the application, which is common on Windows and Linux to close programs. These changes were tested on Arch Linux using JetBrains Rider.

I am open to feedback on implementation, but based on how shortcuts are currently wired, I think I did this in a way that fits the current codebase.

I have worked with Qt in the past, and there is a concept of `KeySequence`s that have built-in shortcuts for some actions. AvalonUI seems to have something similar, but many examples seem to use XML (https://docs.avaloniaui.net/docs/concepts/input/binding-key-and-mouse). I am not familiar enough with the technology here to know if this is relevant to this project. :sweat_smile: 

This is my first experience contributing to a C# codebase. I tried to follow the existing patterns that were in place. Let me know if I missed anything. Thanks!

<hr>

EDIT: This would "work" on macOS, but on that platform, Cmd+Q is more commonly used. As there appears to be ongoing work to support macOS, I can add relevant support to check the correct modifier for macOS, but may need some guidance on how to check the current platform.