### PR TITLE
Fixed mod updates not fetching correct URL

### DIFF
--- a/Source/HedgeModManager/Helpers.cs
+++ b/Source/HedgeModManager/Helpers.cs
@@ -28,6 +28,14 @@ public static class Helpers
     }
 
     /// <summary>
+    /// Ensures that the specified path ends with a trailing forward slash "/"
+    /// </summary>
+    public static string EnsureTrailingSlash(string baseHost)
+    {
+        return baseHost.TrimEnd('/') + '/';
+    }
+
+    /// <summary>
     /// Combines a base URL path and a file path into a single URL
     /// </summary>
     public static string CombineURL(string baseHost, string path)

--- a/Source/HedgeModManager/ModGeneric.cs
+++ b/Source/HedgeModManager/ModGeneric.cs
@@ -97,7 +97,7 @@ public class ModGeneric : IMod
             var server = mainSection.Get("UpdateServer", string.Empty);
             if (!string.IsNullOrEmpty(server))
             {
-                if (Uri.TryCreate(server, UriKind.Absolute, out Uri? uri))
+                if (Uri.TryCreate(Helpers.EnsureTrailingSlash(server), UriKind.Absolute, out Uri? uri))
                 {
                     Updater = new UpdateSourceMulti(this, uri);
                 }


### PR DESCRIPTION
Resolves https://github.com/hedge-dev/HedgeModManager/issues/104

Tested on both Windows and Linux

* Verified Gamebanana updates work as expected
* Verified GitHub updates work as expected

Note: This PR only fixes the broken update functionality. The 'check on startup' is still broken and is unrelated to this PR.