### PR TITLE
Show mod version upgrade and changelog for Update

### DIFF
--- a/Source/HedgeModManager.UI/Controls/Modals/MessageBoxModal.axaml
+++ b/Source/HedgeModManager.UI/Controls/Modals/MessageBoxModal.axaml
@@ -17,7 +17,9 @@
                 HorizontalAlignment="Right" />
   </local:WindowModal.Buttons>
   <local:WindowModal.Data>
-    <TextBlock Text="{Binding Message, RelativeSource={RelativeSource AncestorType=cm:MessageBoxModal}, Converter={StaticResource StringLocalizeConverter}}"
-               FontSize="14" Margin="50,70,100,0" />
+    <ScrollViewer Margin="50,70,100,20">
+      <TextBlock Text="{Binding Message, RelativeSource={RelativeSource AncestorType=cm:MessageBoxModal}}"
+                 FontSize="14" Margin="0,0,100,20" />
+    </ScrollViewer>
   </local:WindowModal.Data>
 </local:WindowModal>

--- a/Source/HedgeModManager.UI/Languages/en-AU.axaml
+++ b/Source/HedgeModManager.UI/Languages/en-AU.axaml
@@ -185,7 +185,7 @@
   <system:String xml:space="preserve" x:Key="Modal.Message.MissingDependency">The mods listed below are missing and are required to play.&#x0a;&#x0a;{0}</system:String>
   <system:String xml:space="preserve" x:Key="Modal.Message.ModLoaderInstallError">An error occurred while trying to install the mod loader.&#x0a;&#x0a;Check log for exception.</system:String>
   <system:String xml:space="preserve" x:Key="Modal.Message.SelectModsError">Hedge Mod Manager does not have permissions to the selected directory.&#x0a;&#x0a;Please select another directory.</system:String>
-  <system:String xml:space="preserve" x:Key="Modal.Message.UpdateMod">There is an update available for {0}.&#x0a;&#x0a;Would you like to update the mod?</system:String>
+  <system:String xml:space="preserve" x:Key="Modal.Message.UpdateMod">There is an update available for {0} ({1} -> {2}).&#x0a;&#x0a;Would you like to update the mod?</system:String>
   <system:String xml:space="preserve" x:Key="Modal.Message.UpdateModError">An unknown error occurred while updating &quot;{0}&quot;.&#x0a;&#x0a;Please try again later.</system:String>
   <system:String xml:space="preserve" x:Key="Modal.Message.UnknownError">An unknown error has occurred.</system:String>
   <system:String xml:space="preserve" x:Key="Modal.Message.UnknownSaveError">Hedge Mod Manager was unable to save&#x0a;due to an unknown error.</system:String>

--- a/Source/HedgeModManager.UI/ViewModels/MainWindowViewModel.cs
+++ b/Source/HedgeModManager.UI/ViewModels/MainWindowViewModel.cs
@@ -260,7 +260,12 @@ public partial class MainWindowViewModel : ViewModelBase
                 Logger.Debug($"  Latest: {info.Version}");
                 if (promptUpdate)
                 {
-                    var messageBox = new MessageBoxModal("Modal.Title.UpdateMod", Localize("Modal.Message.UpdateMod", mod.Title));
+                    var message = Localize("Modal.Message.UpdateMod", mod.Title, mod.Version, info.Version);
+                    if (!string.IsNullOrEmpty(info.Changelog))
+                    {
+                        message += "\n\n" + info.Changelog;
+                    }
+                    var messageBox = new MessageBoxModal(Localize("Modal.Title.UpdateMod"), message);
                     messageBox.AddButton("Common.Button.Cancel", (s, e) => messageBox.Close());
                     messageBox.AddButton("Common.Button.Update", async (s, e) =>
                     {


### PR DESCRIPTION
* Adds a scrollview to the update messagebox, and appends the changelog if available
* Adjust the mod update message to also include the current version and new version, to closer match HMM 7.
* This PR doesn't add markdown parsing. We can either manually parse using something like Markdig, or render it as a webview with an Avalonia.WebView package.


### Before
<img width="1904" height="1015" alt="image" src="https://github.com/user-attachments/assets/9cf8c235-d25e-49c6-8b20-b6fd0e8c3273" />


### After
<img width="1896" height="1011" alt="image" src="https://github.com/user-attachments/assets/2d6dfaea-77bb-4f9c-b1d4-d994da7ab257" />
