### PR TITLE
SharpCompress 0.50.0 | Fix Zip and other non SOLID format support

### DIFF
--- a/Source/HedgeModManager/HedgeModManager.csproj
+++ b/Source/HedgeModManager/HedgeModManager.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.6.0" />
     <PackageReference Include="PeNet" Version="5.1.0" />
-    <PackageReference Include="SharpCompress" Version="0.39.0" />
+    <PackageReference Include="SharpCompress" Version="0.50.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="ValveKeyValue" Version="0.20.0.417" />

--- a/Source/HedgeModManager/ModDatabaseGeneric.cs
+++ b/Source/HedgeModManager/ModDatabaseGeneric.cs
@@ -8,6 +8,7 @@ using System.IO;
 using Text;
 using IO;
 using SharpCompress.Archives;
+using SharpCompress.Common;
 
 public class ModDatabaseGeneric : IModDatabase, IIncludeResolver
 {
@@ -355,7 +356,7 @@ public class ModDatabaseGeneric : IModDatabase, IIncludeResolver
     public async Task<bool> InstallModFromArchive(string archivePath, IProgress<long>? progress)
     {
         // Open archive
-        using var archive = ArchiveFactory.Open(archivePath);
+        using var archive = ArchiveFactory.OpenArchive(archivePath);
         if (archive == null)
             return false;
 
@@ -415,33 +416,66 @@ public class ModDatabaseGeneric : IModDatabase, IIncludeResolver
 
         // Extract files
         long totalBytesRead = 0;
-        var archiveReader = archive.ExtractAllEntries();
 
-        while (archiveReader.MoveToNextEntry())
+        if (archive.IsSolid || archive.Type == ArchiveType.SevenZip)
         {
-            var (modDir, entryPath, entry) = archiveEntries
-                .FirstOrDefault(x => x.Item3.Key == archiveReader.Entry.Key);
+            var archiveReader = archive.ExtractAllEntries();
 
-            if (entry == null)
-                continue;
-
-            string fullPath = Path.Combine(modDir, entryPath);
-            string dir = Path.GetDirectoryName(fullPath)!;
-            if (!Directory.Exists(dir))
-                Directory.CreateDirectory(dir);
-
-            using var archiveFileStream = archiveReader.OpenEntryStream();
-            using var fileStream = File.Create(fullPath);
-
-            var buffer = new byte[1048576];
-            int bytesRead;
-            while ((bytesRead = await archiveFileStream.ReadAsync(buffer)) > 0)
+            while (archiveReader.MoveToNextEntry())
             {
-                await fileStream.WriteAsync(buffer.AsMemory(0, bytesRead));
-                totalBytesRead += bytesRead;
-                progress?.Report(totalBytesRead);
+                var (modDir, entryPath, entry) = archiveEntries
+                    .FirstOrDefault(x => x.Item3.Key == archiveReader.Entry.Key);
+
+                if (entry == null)
+                    continue;
+
+                string fullPath = Path.Combine(modDir, entryPath);
+                string dir = Path.GetDirectoryName(fullPath)!;
+                if (!Directory.Exists(dir))
+                    Directory.CreateDirectory(dir);
+
+                using var archiveFileStream = archiveReader.OpenEntryStream();
+                using var fileStream = File.Create(fullPath);
+
+                var buffer = new byte[1048576];
+                int bytesRead;
+                while ((bytesRead = await archiveFileStream.ReadAsync(buffer)) > 0)
+                {
+                    await fileStream.WriteAsync(buffer.AsMemory(0, bytesRead));
+                    totalBytesRead += bytesRead;
+                    progress?.Report(totalBytesRead);
+                }
+                await archiveFileStream.DisposeAsync();
             }
-            await archiveFileStream.DisposeAsync();
+        }
+        else
+        {
+            foreach (var archiveEntry in archive.Entries.Where(x => x.Key != null && !x.IsDirectory))
+            {
+                var (modDir, entryPath, entry) = archiveEntries
+                    .FirstOrDefault(x => x.Item3.Key == archiveEntry.Key);
+
+                if (entry == null)
+                    continue;
+
+                string fullPath = Path.Combine(modDir, entryPath);
+                string dir = Path.GetDirectoryName(fullPath)!;
+                if (!Directory.Exists(dir))
+                    Directory.CreateDirectory(dir);
+
+                using var archiveFileStream = archiveEntry.OpenEntryStream();
+                using var fileStream = File.Create(fullPath);
+
+                var buffer = new byte[1048576];
+                int bytesRead;
+                while ((bytesRead = await archiveFileStream.ReadAsync(buffer)) > 0)
+                {
+                    await fileStream.WriteAsync(buffer.AsMemory(0, bytesRead));
+                    totalBytesRead += bytesRead;
+                    progress?.Report(totalBytesRead);
+                }
+                await archiveFileStream.DisposeAsync();
+            }
         }
         return true;
     }

--- a/Source/HedgeModManager/ModDatabaseGeneric.cs
+++ b/Source/HedgeModManager/ModDatabaseGeneric.cs
@@ -434,7 +434,7 @@ public class ModDatabaseGeneric : IModDatabase, IIncludeResolver
                 if (!Directory.Exists(dir))
                     Directory.CreateDirectory(dir);
 
-                using var archiveFileStream = archiveReader.OpenEntryStream();
+                await using var archiveFileStream = archiveReader.OpenEntryStream();
                 using var fileStream = File.Create(fullPath);
 
                 var buffer = new byte[1048576];
@@ -445,7 +445,6 @@ public class ModDatabaseGeneric : IModDatabase, IIncludeResolver
                     totalBytesRead += bytesRead;
                     progress?.Report(totalBytesRead);
                 }
-                await archiveFileStream.DisposeAsync();
             }
         }
         else
@@ -463,7 +462,7 @@ public class ModDatabaseGeneric : IModDatabase, IIncludeResolver
                 if (!Directory.Exists(dir))
                     Directory.CreateDirectory(dir);
 
-                using var archiveFileStream = archiveEntry.OpenEntryStream();
+                await using var archiveFileStream = archiveEntry.OpenEntryStream();
                 using var fileStream = File.Create(fullPath);
 
                 var buffer = new byte[1048576];
@@ -474,7 +473,6 @@ public class ModDatabaseGeneric : IModDatabase, IIncludeResolver
                     totalBytesRead += bytesRead;
                     progress?.Report(totalBytesRead);
                 }
-                await archiveFileStream.DisposeAsync();
             }
         }
         return true;


### PR DESCRIPTION
For https://github.com/hedge-dev/HedgeModManager/issues/136

This could probably be further simplified to share code (its very few actual changes between the two paths). That said feel free to close this with a better implementation if you go that route.

Fixes the wrong extraction call being used on zips, explicitly blocked with SharpCompress > 0.48