### PR TITLE
Target NET 10 / FreeDesktop 25.08 / Update Actions

### DIFF
--- a/.github/workflows/build-project.yml
+++ b/.github/workflows/build-project.yml
@@ -25,17 +25,17 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Setup .NET ${{ env.DOTNET_VERSION }} SDK
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}.0.x
       
       - name: Setup .NET ${{ env.DOTNET_VERSION }} Cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ${{ env.DOTNET_CLI_HOME }}
           key: dotnet-${{ env.DOTNET_VERSION }}-${{ matrix.rid }}
@@ -67,7 +67,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -77,7 +77,7 @@ jobs:
           sudo apt-get install flatpak-builder -y
           
       - name: Setup Flatpak Cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ~/.local/share/flatpak/runtime/
           key: flatpak-${{ env.FREEDESKTOP_VERSION }}-${{ matrix.arch }}

--- a/.github/workflows/build-project.yml
+++ b/.github/workflows/build-project.yml
@@ -11,9 +11,9 @@ env:
   PROJECT_PATH: ./Source/HedgeModManager.UI/HedgeModManager.UI.csproj
   FLATPAK_ID: io.github.hedge_dev.hedgemodmanager
   GENERATOR_URL: https://raw.githubusercontent.com/flatpak/flatpak-builder-tools/refs/heads/master/dotnet/flatpak-dotnet-generator.py
-  DOTNET_VERSION: 8
+  DOTNET_VERSION: 10
   DOTNET_CLI_HOME: /tmp/.dotnet
-  FREEDESKTOP_VERSION: 24.08
+  FREEDESKTOP_VERSION: 25.08
 
 jobs:
   build:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -16,14 +16,16 @@ env:
   PROJECT_PATH: ./Source/HedgeModManager.UI/HedgeModManager.UI.csproj
   FLATPAK_ID: io.github.hedge_dev.hedgemodmanager
   GENERATOR_URL: https://raw.githubusercontent.com/flatpak/flatpak-builder-tools/refs/heads/master/dotnet/flatpak-dotnet-generator.py
-  DOTNET_VERSION: 8
+  DOTNET_VERSION: 10
   DOTNET_CLI_HOME: /tmp/.dotnet
-  FREEDESKTOP_VERSION: 24.08
+  FREEDESKTOP_VERSION: 25.08
 
 jobs:
   build-all:
     name: Build All
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout Repository

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -29,12 +29,12 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Setup .NET ${{ env.DOTNET_VERSION }} SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}.0.x
 
@@ -44,13 +44,13 @@ jobs:
           sudo apt-get install flatpak-builder -y
       
       - name: Setup Flatpak Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.local/share/flatpak/runtime/
           key: flatpak-${{ env.FREEDESKTOP_VERSION }}
 
       - name: Setup .NET ${{ env.DOTNET_VERSION }} Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ${{ env.DOTNET_CLI_HOME }}
           key: dotnet-${{ env.DOTNET_VERSION }}
@@ -90,7 +90,7 @@ jobs:
           tar -czvf ./release/HedgeModManager-linux-x64.tar.gz ./output/linux-x64
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2.2.1
+        uses: softprops/action-gh-release@v3.0.2
         with:
           files: |
             ./release/*
@@ -104,7 +104,7 @@ jobs:
             - Fixed 
 
       - name: Upload NuGet Sources
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: nuget-sources.json
           path: ./flatpak/nuget-sources.json

--- a/.github/workflows/publish-nuget-packages.yml
+++ b/.github/workflows/publish-nuget-packages.yml
@@ -13,10 +13,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup .NET 8
+      - name: Setup .NET 10
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 10.0.x
 
       - name: Pack Libraries
         working-directory: Source

--- a/.github/workflows/publish-nuget-packages.yml
+++ b/.github/workflows/publish-nuget-packages.yml
@@ -9,12 +9,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Setup .NET 10
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: 10.0.x
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ A mod manager for Hedgehog Engine games on PC.
 #### Windows
 Download the Windows binary from the [releases page](https://github.com/hedge-dev/HedgeModManager/releases) and store it anywhere. Avoid using multiple copies such as placing a copy of Hedge Mod Manager in every game folder.
 > [!NOTE]
-> .NET 8 Runtime or newer is required to run Hedge Mod Manager. This can be downloaded [here](https://dotnet.microsoft.com/en-us/download/dotnet/9.0).
+> .NET 10 Runtime or newer is required to run Hedge Mod Manager. This can be downloaded [here](https://dotnet.microsoft.com/en-us/download/dotnet/10.0).
 >
 > Make sure you are downloading the **Installer** of **.NET Runtime**. For most systems the **x64** **Installer** is the correct option. 
 

--- a/Source/HedgeModManager.Console/HedgeModManager.Console.csproj
+++ b/Source/HedgeModManager.Console/HedgeModManager.Console.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/Source/HedgeModManager.Console/Properties/PublishProfiles/FolderProfile.pubxml
+++ b/Source/HedgeModManager.Console/Properties/PublishProfiles/FolderProfile.pubxml
@@ -6,10 +6,10 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <Configuration>Release</Configuration>
     <Platform>Any CPU</Platform>
-    <PublishDir>bin\Release\net7.0\publish\win-x64\</PublishDir>
+    <PublishDir>bin\Release\net10.0\publish\win-x64\</PublishDir>
     <PublishProtocol>FileSystem</PublishProtocol>
     <_TargetId>Folder</_TargetId>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <SelfContained>false</SelfContained>
     <PublishSingleFile>true</PublishSingleFile>

--- a/Source/HedgeModManager.UI/HedgeModManager.UI.csproj
+++ b/Source/HedgeModManager.UI/HedgeModManager.UI.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
     <ApplicationManifest>app.manifest</ApplicationManifest>

--- a/Source/HedgeModManager/HedgeModManager.csproj
+++ b/Source/HedgeModManager/HedgeModManager.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -13,8 +13,6 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.6.0" />
     <PackageReference Include="PeNet" Version="5.1.0" />
     <PackageReference Include="SharpCompress" Version="0.50.0" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="ValveKeyValue" Version="0.20.0.417" />
   </ItemGroup>
 

--- a/Source/Libraries/HedgeModManager.Epic/HedgeModManager.Epic.csproj
+++ b/Source/Libraries/HedgeModManager.Epic/HedgeModManager.Epic.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/Source/Libraries/HedgeModManager.Foundation/HedgeModManager.Foundation.csproj
+++ b/Source/Libraries/HedgeModManager.Foundation/HedgeModManager.Foundation.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/Source/Libraries/HedgeModManager.Steam/HedgeModManager.Steam.csproj
+++ b/Source/Libraries/HedgeModManager.Steam/HedgeModManager.Steam.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/Source/Libraries/HedgeModManager.Text/HedgeModManager.Text.csproj
+++ b/Source/Libraries/HedgeModManager.Text/HedgeModManager.Text.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/flatpak/io.github.hedge_dev.hedgemodmanager-autobuild.yml
+++ b/flatpak/io.github.hedge_dev.hedgemodmanager-autobuild.yml
@@ -1,13 +1,13 @@
 app-id: io.github.hedge_dev.hedgemodmanager
 runtime: org.freedesktop.Platform
-runtime-version: "24.08"
+runtime-version: "25.08"
 sdk: org.freedesktop.Sdk
 sdk-extensions:
-  - org.freedesktop.Sdk.Extension.dotnet8
+  - org.freedesktop.Sdk.Extension.dotnet10
 build-options:
-  prepend-path: /usr/lib/sdk/dotnet8/bin
-  append-ld-library-path: /usr/lib/sdk/dotnet8/lib
-  prepend-pkg-config-path: /usr/lib/sdk/dotnet8/lib/pkgconfig
+  prepend-path: /usr/lib/sdk/dotnet10/bin
+  append-ld-library-path: /usr/lib/sdk/dotnet10/lib
+  prepend-pkg-config-path: /usr/lib/sdk/dotnet10/lib/pkgconfig
 
 command: HedgeModManager.UI
 
@@ -39,7 +39,7 @@ modules:
   - name: dotnet
     buildsystem: simple
     build-commands:
-      - /usr/lib/sdk/dotnet8/bin/install.sh
+      - /usr/lib/sdk/dotnet10/bin/install.sh
   - name: hedge-mod-manager
     buildsystem: simple
     build-options:
@@ -59,7 +59,7 @@ modules:
     build-commands:
       - dotnet publish Source/HedgeModManager.UI/HedgeModManager.UI.csproj -c Release -p:DefineConstants=COMMITBUILD -p:PublishProfile=${PUBLISH_PROFILE} --no-self-contained --source ./nuget-sources
       - mkdir -p ${FLATPAK_DEST}/bin
-      - cp -r Source/HedgeModManager.UI/bin/Release/net8.0/publish/* ${FLATPAK_DEST}/bin
+      - cp -r Source/HedgeModManager.UI/bin/Release/net10.0/publish/* ${FLATPAK_DEST}/bin
       - install -Dm644 flatpak/hedgemodmanager.png ${FLATPAK_DEST}/share/icons/hicolor/256x256/apps/${FLATPAK_ID}.png
       - install -Dm644 flatpak/hedgemodmanager.metainfo.xml ${FLATPAK_DEST}/share/metainfo/${FLATPAK_ID}.metainfo.xml
       - install -Dm644 flatpak/hedgemodmanager.desktop ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop

--- a/flatpak/io.github.hedge_dev.hedgemodmanager.yml
+++ b/flatpak/io.github.hedge_dev.hedgemodmanager.yml
@@ -1,13 +1,13 @@
 app-id: io.github.hedge_dev.hedgemodmanager
 runtime: org.freedesktop.Platform
-runtime-version: "24.08"
+runtime-version: "25.08"
 sdk: org.freedesktop.Sdk
 sdk-extensions:
-  - org.freedesktop.Sdk.Extension.dotnet8
+  - org.freedesktop.Sdk.Extension.dotnet10
 build-options:
-  prepend-path: /usr/lib/sdk/dotnet8/bin
-  append-ld-library-path: /usr/lib/sdk/dotnet8/lib
-  prepend-pkg-config-path: /usr/lib/sdk/dotnet8/lib/pkgconfig
+  prepend-path: /usr/lib/sdk/dotnet10/bin
+  append-ld-library-path: /usr/lib/sdk/dotnet10/lib
+  prepend-pkg-config-path: /usr/lib/sdk/dotnet10/lib/pkgconfig
 
 command: HedgeModManager.UI
 
@@ -39,7 +39,7 @@ modules:
   - name: dotnet
     buildsystem: simple
     build-commands:
-      - /usr/lib/sdk/dotnet8/bin/install.sh
+      - /usr/lib/sdk/dotnet10/bin/install.sh
   - name: hedge-mod-manager
     buildsystem: simple
     sources:
@@ -49,7 +49,7 @@ modules:
     build-commands:
       - dotnet publish Source/HedgeModManager.UI/HedgeModManager.UI.csproj -c Release --no-self-contained --source ./nuget-sources
       - mkdir -p ${FLATPAK_DEST}/bin
-      - cp -r Source/HedgeModManager.UI/bin/Release/net8.0/publish/* ${FLATPAK_DEST}/bin
+      - cp -r Source/HedgeModManager.UI/bin/Release/net10.0/publish/* ${FLATPAK_DEST}/bin
       - install -Dm644 flatpak/hedgemodmanager.png ${FLATPAK_DEST}/share/icons/hicolor/256x256/apps/${FLATPAK_ID}.png
       - install -Dm644 flatpak/hedgemodmanager.metainfo.xml ${FLATPAK_DEST}/share/metainfo/${FLATPAK_ID}.metainfo.xml
       - install -Dm644 flatpak/hedgemodmanager.desktop ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop


### PR DESCRIPTION
NET 8 goes EOL in a few months (November 10, 2026)

Other than swapping target and runners to use net 10, clarifying these changes:

* Updates the actions (not needed for NET 10, but just since I'm touching the CI anyway)
* System.Net.Http & System.Text.RegularExpressions -> dropped since implicit in NET 10 now
* Using FreeDesktop 25.08 instead of 24.08 runtime - technically unnecessary since 24.08 also has the extension for dotnet10, but there's really no reason to not use 25.08 (works fine with Unleashed still on 24.08 - though I imagine they'll update next release)
* permissions write in CI files - only an issue for new repos (or people who fork your repo) and want to test the release publish step. I can remove if you prefer, but its implicitly true for this repo.

This works fine with Avalonia 11, but I was planning to open an Avalonia 12 PR next.
I ignored the existing DBus vuln warning (we got it too for ShadowRando) since its resolved after updating to Avalonia 12

~~Please don't merge until I test the artifacts the CI generates just to be 100% safe; Only tested local compile.~~
I'll mark ready / non-draft once I finish. :heavy_check_mark:   - completed

Build:
https://github.com/dreamsyntax/HedgeModManager/actions/runs/29445753839

Release:
https://github.com/dreamsyntax/HedgeModManager/actions/runs/29445765254

Test (x86 only, I don't have an arm device - but no reason it should break there)
[x] Windows
[x] Linux (native)
[x] Linux (flatpak)

<img width="1631" height="964" alt="image" src="https://github.com/user-attachments/assets/7bfffa92-1222-40fc-bfe2-7d6dc6766375" />
