### PR TITLE
Upgrade to Avalonia 12

### DIFF
--- a/.github/workflows/build-project.yml
+++ b/.github/workflows/build-project.yml
@@ -61,8 +61,10 @@ jobs:
         include:
         - arch: x86_64
           runner: ubuntu-26.04
+          runtime: linux-x64
         - arch: aarch64
           runner: ubuntu-26.04-arm
+          runtime: linux-arm64
     runs-on: ${{ matrix.runner }}
 
     steps:
@@ -92,7 +94,7 @@ jobs:
         run: |
           curl -o flatpak-dotnet-generator.py ${{env.GENERATOR_URL}}
           chmod +x flatpak-dotnet-generator.py
-          python3 flatpak-dotnet-generator.py ./flatpak/nuget-sources.json ${{env.PROJECT_PATH}} --dotnet ${{env.DOTNET_VERSION}} --freedesktop ${{env.FREEDESKTOP_VERSION}}
+          python3 flatpak-dotnet-generator.py ./flatpak/nuget-sources.json ${{env.PROJECT_PATH}} --dotnet ${{env.DOTNET_VERSION}} --freedesktop ${{env.FREEDESKTOP_VERSION}} --runtime ${{ matrix.runtime }}
 
       - name: Build Flatpak
         run: flatpak-builder --user --arch=${{ matrix.arch }} --force-clean --install-deps-from=flathub --repo=repo builddir ./flatpak/${{ env.FLATPAK_ID }}-autobuild.yml

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -68,7 +68,7 @@ jobs:
         run: |
           curl -o flatpak-dotnet-generator.py ${{env.GENERATOR_URL}}
           chmod +x flatpak-dotnet-generator.py
-          python3 flatpak-dotnet-generator.py ./flatpak/nuget-sources.json ${{env.PROJECT_PATH}} --dotnet ${{env.DOTNET_VERSION}} --freedesktop ${{env.FREEDESKTOP_VERSION}}
+          python3 flatpak-dotnet-generator.py ./flatpak/nuget-sources.json ${{env.PROJECT_PATH}} --dotnet ${{env.DOTNET_VERSION}} --freedesktop ${{env.FREEDESKTOP_VERSION}} --runtime linux-x64
       
       - name: win-x64 Build
         run: dotnet publish -p:PublishProfile=win-x64 -c Release -o ./output/win-x64 ${{env.PROJECT_PATH}}

--- a/Source/HedgeModManager.UI/App.axaml.cs
+++ b/Source/HedgeModManager.UI/App.axaml.cs
@@ -1,7 +1,6 @@
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
-using Avalonia.Data.Core.Plugins;
 using Avalonia.Markup.Xaml;
 using Avalonia.Markup.Xaml.Styling;
 using HedgeModManager.Foundation;
@@ -82,10 +81,6 @@ public partial class App : Application
     {
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
-            // Line below is needed to remove Avalonia data validation.
-            // Without this line you will get duplicate validations from both Avalonia and CT
-            BindingPlugins.DataValidators.RemoveAt(0);
-
             var languages = GetLanguages();
             var viewModel = new MainWindowViewModel(new UILogger(), languages);
             viewModel.IsGamescope = Environment.GetEnvironmentVariable("XDG_CURRENT_DESKTOP") == "gamescope";

--- a/Source/HedgeModManager.UI/Controls/Codes/Codes.axaml
+++ b/Source/HedgeModManager.UI/Controls/Codes/Codes.axaml
@@ -15,7 +15,7 @@
   <Grid RowDefinitions="Auto,*" ColumnDefinitions="2*,1*"
         Margin="8,0,0,0">
     <Grid Grid.Row="0" Grid.Column="0" RowDefinitions="Auto" ColumnDefinitions="2*,1*">
-      <TextBox Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2" Watermark="{DynamicResource Codes.Text.Search}"
+      <TextBox Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2" PlaceholderText="{DynamicResource Codes.Text.Search}"
                FontSize="14" Height="28"
                Text="{Binding Search, RelativeSource={RelativeSource AncestorType=cc:Codes}}"
                Margin="4,23,32,8"

--- a/Source/HedgeModManager.UI/Controls/MainWindow/Mods.axaml
+++ b/Source/HedgeModManager.UI/Controls/MainWindow/Mods.axaml
@@ -18,7 +18,7 @@
   <Border Margin="12">
     <Grid RowDefinitions="Auto,*">
       <Grid Grid.Row="0" RowDefinitions="Auto,Auto" ColumnDefinitions="50,2*,*,*,Auto">        
-        <TextBox Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2" Watermark="{DynamicResource Mods.Text.Search}"
+        <TextBox Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2" PlaceholderText="{DynamicResource Mods.Text.Search}"
                  FontSize="14" Height="28"
                  Text="{Binding Search, RelativeSource={RelativeSource AncestorType=cmw:Mods}}"
                  Margin="0,0,8,0"

--- a/Source/HedgeModManager.UI/Controls/MainWindow/Test.axaml
+++ b/Source/HedgeModManager.UI/Controls/MainWindow/Test.axaml
@@ -87,7 +87,7 @@
           <ItemsControl ItemsSource="{Binding LoggerInstance.Logs}">
             <ItemsControl.ItemTemplate>
               <DataTemplate>
-                <TextBlock FontFamily="DejaVu Sans Mono, Consolas" Text="{Binding, Converter={StaticResource LogStringConverter}}" />
+                <TextBlock FontFamily="DejaVu Sans Mono, Consolas" Text="{Binding Converter={StaticResource LogStringConverter}}" />
               </DataTemplate>
             </ItemsControl.ItemTemplate>
           </ItemsControl>

--- a/Source/HedgeModManager.UI/Controls/Modals/ModConfigModal.axaml.cs
+++ b/Source/HedgeModManager.UI/Controls/Modals/ModConfigModal.axaml.cs
@@ -139,7 +139,7 @@ public partial class ModConfigModal : UserControl
 
         foreach (var group in ConfigViewModel.Config.Groups)
         {
-            var groupBox = new GroupBox()
+            var groupBox = new Basic.GroupBox()
             {
                 Header = group.DisplayName,
                 Margin = new Thickness(16, 4, 16, 4)

--- a/Source/HedgeModManager.UI/Controls/Modals/ProfileRenameModal.axaml
+++ b/Source/HedgeModManager.UI/Controls/Modals/ProfileRenameModal.axaml
@@ -30,7 +30,7 @@
       <TextBlock Text="{DynamicResource Modal.Text.NewProfileName}"
                  VerticalAlignment="Center" />
       <TextBox Text="{Binding NewName, RelativeSource={RelativeSource AncestorType=local:ProfileRenameModal}}"
-               Watermark="{Binding SelectedProfile.Name, RelativeSource={RelativeSource AncestorType=local:ProfileRenameModal}}"
+               PlaceholderText="{Binding SelectedProfile.Name, RelativeSource={RelativeSource AncestorType=local:ProfileRenameModal}}"
                HorizontalAlignment="Stretch" VerticalAlignment="Top" />
     </StackPanel>
   </local:WindowModal.Data>

--- a/Source/HedgeModManager.UI/Controls/Modals/ReportViewerModal.axaml.cs
+++ b/Source/HedgeModManager.UI/Controls/Modals/ReportViewerModal.axaml.cs
@@ -1,4 +1,5 @@
 using Avalonia.Controls;
+using Avalonia.Input.Platform;
 using Avalonia.Interactivity;
 using Avalonia.Markup.Xaml;
 using HedgeModManager.Diagnostics;

--- a/Source/HedgeModManager.UI/Controls/Settings/SettingsEntry.axaml
+++ b/Source/HedgeModManager.UI/Controls/Settings/SettingsEntry.axaml
@@ -1,9 +1,10 @@
-<ButtonUserControl xmlns="https://github.com/avaloniaui"
+<primitives:ButtonUserControl xmlns="https://github.com/avaloniaui"
                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                    xmlns:local="using:HedgeModManager.UI.Controls.Settings"
                    xmlns:materialIcons="using:Material.Icons.Avalonia"
                    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                   xmlns:primitives="clr-namespace:HedgeModManager.UI.Controls.Primitives"
                    mc:Ignorable="d" d:DesignWidth="600" d:DesignHeight="64"
                    x:Class="HedgeModManager.UI.Controls.Settings.SettingsEntry"
                    Loaded="OnLoaded">
@@ -52,4 +53,4 @@
     </Border.Styles>
 
   </Border>
-</ButtonUserControl>
+</primitives:ButtonUserControl>

--- a/Source/HedgeModManager.UI/HedgeModManager.UI.csproj
+++ b/Source/HedgeModManager.UI/HedgeModManager.UI.csproj
@@ -28,16 +28,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.3.3" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.3.3" />
-    <PackageReference Include="Avalonia.HtmlRenderer" Version="11.2.0" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.3" />
-    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.3" />
-    <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.3.3" />
+    <PackageReference Include="Avalonia" Version="12.1.0" />
+    <PackageReference Include="Avalonia.Desktop" Version="12.1.0" />
+    <PackageReference Include="Avalonia.HtmlRenderer" Version="12.0.0" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.1.0" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="12.1.0" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageReference Include="Markdig" Version="0.41.3" />
-    <PackageReference Include="Material.Icons.Avalonia" Version="2.2.0" />
+    <PackageReference Include="Material.Icons.Avalonia" Version="3.0.2" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.8.38-alpha">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Source/HedgeModManager.UI/Views/MainWindow.axaml.cs
+++ b/Source/HedgeModManager.UI/Views/MainWindow.axaml.cs
@@ -18,9 +18,6 @@ public partial class MainWindow : Window
     public MainWindow()
     {
         AvaloniaXamlLoader.Load(this);
-#if DEBUG
-        this.AttachDevTools();
-#endif
     }
 
     public void LoadGames()
@@ -233,16 +230,16 @@ public partial class MainWindow : Window
 
     private void OnDragOver(object? sender, DragEventArgs e)
     {
-        if (ViewModel == null || !e.Data.Contains(DataFormats.Files))
+        if (ViewModel == null || !e.DataTransfer.Formats.Contains(DataFormat.File))
             return;
         e.DragEffects = DragDropEffects.Copy;
     }
 
     private void OnDrop(object? sender, DragEventArgs e)
     {
-        if (ViewModel == null || !e.Data.Contains(DataFormats.Files))
+        if (ViewModel == null || !e.DataTransfer.Formats.Contains(DataFormat.File))
             return;
-        foreach (var file in e.Data.GetFiles() ?? [])
+        foreach (var file in e.DataTransfer.TryGetFiles() ?? [])
             ViewModel.InstallMod(file.Name, Utils.ConvertToPath(file.Path), null);
     }
 }

--- a/flatpak/io.github.hedge_dev.hedgemodmanager-autobuild.yml
+++ b/flatpak/io.github.hedge_dev.hedgemodmanager-autobuild.yml
@@ -44,14 +44,14 @@ modules:
     buildsystem: simple
     build-options:
       env:
-        PUBLISH_PROFILE: linux-x86_64
+        PUBLISH_PROFILE: linux-x64
       arch:
         x86_64:
           env:
-            PUBLISH_PROFILE: linux-x86_64
+            PUBLISH_PROFILE: linux-x64
         aarch64:
           env:
-            PUBLISH_PROFILE: linux-arm
+            PUBLISH_PROFILE: linux-arm64
     sources:
       - type: dir
         path: ../
@@ -59,7 +59,7 @@ modules:
     build-commands:
       - dotnet publish Source/HedgeModManager.UI/HedgeModManager.UI.csproj -c Release -p:DefineConstants=COMMITBUILD -p:PublishProfile=${PUBLISH_PROFILE} --no-self-contained --source ./nuget-sources
       - mkdir -p ${FLATPAK_DEST}/bin
-      - cp -r Source/HedgeModManager.UI/bin/Release/net10.0/publish/* ${FLATPAK_DEST}/bin
+      - cp -r Source/HedgeModManager.UI/bin/Release/net10.0/${PUBLISH_PROFILE}/publish/* ${FLATPAK_DEST}/bin
       - install -Dm644 flatpak/hedgemodmanager.png ${FLATPAK_DEST}/share/icons/hicolor/256x256/apps/${FLATPAK_ID}.png
       - install -Dm644 flatpak/hedgemodmanager.metainfo.xml ${FLATPAK_DEST}/share/metainfo/${FLATPAK_ID}.metainfo.xml
       - install -Dm644 flatpak/hedgemodmanager.desktop ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop

--- a/flatpak/io.github.hedge_dev.hedgemodmanager.yml
+++ b/flatpak/io.github.hedge_dev.hedgemodmanager.yml
@@ -42,14 +42,24 @@ modules:
       - /usr/lib/sdk/dotnet10/bin/install.sh
   - name: hedge-mod-manager
     buildsystem: simple
+    build-options:
+      env:
+        PUBLISH_PROFILE: linux-x64
+      arch:
+        x86_64:
+          env:
+            PUBLISH_PROFILE: linux-x64
+        aarch64:
+          env:
+            PUBLISH_PROFILE: linux-arm64
     sources:
       - type: dir
         path: ../
       - ./nuget-sources.json
     build-commands:
-      - dotnet publish Source/HedgeModManager.UI/HedgeModManager.UI.csproj -c Release --no-self-contained --source ./nuget-sources
+      - dotnet publish Source/HedgeModManager.UI/HedgeModManager.UI.csproj -c Release -p:PublishProfile=${PUBLISH_PROFILE} --no-self-contained --source ./nuget-sources
       - mkdir -p ${FLATPAK_DEST}/bin
-      - cp -r Source/HedgeModManager.UI/bin/Release/net10.0/publish/* ${FLATPAK_DEST}/bin
+      - cp -r Source/HedgeModManager.UI/bin/Release/net10.0/${PUBLISH_PROFILE}/publish/* ${FLATPAK_DEST}/bin
       - install -Dm644 flatpak/hedgemodmanager.png ${FLATPAK_DEST}/share/icons/hicolor/256x256/apps/${FLATPAK_ID}.png
       - install -Dm644 flatpak/hedgemodmanager.metainfo.xml ${FLATPAK_DEST}/share/metainfo/${FLATPAK_ID}.metainfo.xml
       - install -Dm644 flatpak/hedgemodmanager.desktop ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop


### PR DESCRIPTION
- Migrate drag-drop to new format
- Removed AttachDevTools and BindingPlugins (Avalonia 12 dropped these) - There is a paid plugin now replacing Avalonia.Diagnostics (it is free for open source, but you have to request a license). Removed for now.
- Watermark to PlaceholderText (same functionality / watermark is deprecated, just a renamed prop)
- Rename custom GroupBox as Basic (Avalonia 12 has a built in now. Made sure it is still using the custom one you designed)

One big perk of Avalonia 12 is Drag & Drop finally working regardless of Wayland (XWayland) or X11 for linux. Attached a video of before and after.
https://github.com/user-attachments/assets/29351089-1daf-44c4-91b5-248d41aebb75



I did not include the 'run as Wayland' or DPI fixes yet, going to have that as a separate PR. It may be worth waiting until the decorators for Wayland get finalized before pulling in Avalonia.Wayland, otherwise only the generic Wayland window icon will display on the title bar.