### PR TITLE
[Blocked] Linux: Use Wayland by default; fallback to X11

### DIFF
--- a/Source/HedgeModManager.UI/HedgeModManager.UI.csproj
+++ b/Source/HedgeModManager.UI/HedgeModManager.UI.csproj
@@ -33,6 +33,7 @@
     <PackageReference Include="Avalonia.HtmlRenderer" Version="12.0.0" />
     <PackageReference Include="Avalonia.Themes.Fluent" Version="12.1.0" />
     <PackageReference Include="Avalonia.Fonts.Inter" Version="12.1.0" />
+    <PackageReference Include="Avalonia.Wayland" Version="12.1.0" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageReference Include="Markdig" Version="0.41.3" />
     <PackageReference Include="Material.Icons.Avalonia" Version="3.0.2" />

--- a/Source/HedgeModManager.UI/Program.cs
+++ b/Source/HedgeModManager.UI/Program.cs
@@ -210,7 +210,31 @@ public sealed class Program
     // Avalonia configuration, don't remove; also used by visual designer.
     public static AppBuilder BuildAvaloniaApp()
         => AppBuilder.Configure<App>()
-            .UsePlatformDetect()
+            .UsePlatformDetectPreferWayland()
             .WithInterFont()
             .LogToTrace();
+}
+
+internal static class LinuxPlatformDetector
+{
+    public static AppBuilder UsePlatformDetectPreferWayland(this AppBuilder builder)
+    {
+        if (!OperatingSystem.IsLinux())
+            return builder.UsePlatformDetect();
+
+        if (IsWaylandSession())
+            builder.UseWayland();
+        else
+            builder.UseX11();
+
+        builder.UseSkia().UseHarfBuzz();
+        return builder;
+    }
+
+    private static bool IsWaylandSession()
+        => !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("WAYLAND_DISPLAY"))
+           || string.Equals(
+               Environment.GetEnvironmentVariable("XDG_SESSION_TYPE"),
+               "wayland",
+               StringComparison.OrdinalIgnoreCase);
 }

--- a/flatpak/io.github.hedge_dev.hedgemodmanager-autobuild.yml
+++ b/flatpak/io.github.hedge_dev.hedgemodmanager-autobuild.yml
@@ -12,7 +12,8 @@ build-options:
 command: HedgeModManager.UI
 
 finish-args:
-  - --socket=x11
+  - --socket=fallback-x11
+  - --socket=wayland
   # UnleashedRecomp permissions
   - --filesystem=~/.config/UnleashedRecomp
   - --filesystem=~/.local/share/applications/UnleashedRecomp.desktop:ro

--- a/flatpak/io.github.hedge_dev.hedgemodmanager.yml
+++ b/flatpak/io.github.hedge_dev.hedgemodmanager.yml
@@ -12,7 +12,8 @@ build-options:
 command: HedgeModManager.UI
 
 finish-args:
-  - --socket=x11
+  - --socket=fallback-x11
+  - --socket=wayland
   # UnleashedRecomp permissions
   - --filesystem=~/.config/UnleashedRecomp
   - --filesystem=~/.local/share/applications/UnleashedRecomp.desktop:ro


### PR DESCRIPTION
BLOCKED/PENDING:
- [ ] Waiting for KDE Window Decorator support (expected in Avalonia UI 12.2.0+)
- [ ] Fullscreen breaks layout until context changes 

------

Simple/light Wayland support for Linux. There's a few ways to handle this, but I grabbed what's been working for ShadowONE.

Until Avalonia 12.2.0 (or later) comes out, window icons will be missing:

Note the top left icon will be a "W" when running with Wayland.
<img width="1650" height="993" alt="image" src="https://github.com/user-attachments/assets/a51718ca-e218-4a71-a742-d7938af2b2a0" />


> Currently, Wayland renders through EGL (with an optional dmabuf path). It supports all core functionalities you would expect: mouse, touch, keyboard, clipboard, drag-and-drop... However, a few KDE-specific niceties (global app menu, window icons, blur-behind) are planned as follow-ups.
https://avaloniaui.net/blog/release-12-1

If the Window icon is a dealbreaker, I would suggest to wait until the next Avalonia 12 update.


I will note that scaling behavior seems the same regardless of X11/Wayland - so there's not much of an advantage to have this in now other than to be ahead of the curve.
