### PR TITLE
Fix duplicate codes appearing in list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -215,3 +215,7 @@ _Pvt_Extensions/
 ModelManifest.xml
 
 Ignored/
+
+# JetBrains IDEs (Rider)
+.idea/
+Source/.idea/

--- a/Source/HedgeModManager.UI/ViewModels/MainWindowViewModel.cs
+++ b/Source/HedgeModManager.UI/ViewModels/MainWindowViewModel.cs
@@ -351,7 +351,7 @@ public partial class MainWindowViewModel : ViewModelBase
             {
                 try
                 {
-                    await UpdateCodesAsync(Config.CheckCodeUpdates, true);
+                    await UpdateCodesAsync(Config.CheckCodeUpdates, false);
 
                     if (Config.CheckModLoaderUpdates)
                         await CheckForModLoaderUpdatesAsync();


### PR DESCRIPTION
Simple fix to a bug introduced in commit 1230689402e26958e3112c9a80804ab379a0fd84 
The codes list has duplicate codes until you push "Update Codes" every time.

<img width="1320" height="786" alt="image" src="https://github.com/user-attachments/assets/0e6aa822-ebab-49cc-baba-77e2d27069c1" />


InitializeAsync will run on game change, so this will work properly for both the game switch and normal startup case.


Also added an unrelated gitignore update, because I use Rider and this was annoying me. I can move it to its own PR if you prefer.