### PR TITLE
CodeCompiler: export fields marked as metadata to JSON string in codes

### DIFF
--- a/Source/Libraries/HedgeModManager.CodeCompiler/CSharpCode.cs
+++ b/Source/Libraries/HedgeModManager.CodeCompiler/CSharpCode.cs
@@ -5,25 +5,32 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis;
 using PreProcessor;
 using System.Text;
+using System.Text.Json;
 using Foundation;
 
 public class CSharpCode : ICode
 {
     private string mBody = string.Empty;
     private SyntaxTreeEx? mCachedSyntaxTree;
-    
+
+    [CodeMetadata]
     public string ID { get; set; } = string.Empty;
+
+    [CodeMetadata]
     public string Name { get; set; } = string.Empty;
 
-    public string Category { get; set; } = string.Empty;
-
+    [CodeMetadata]
     public string Author { get; set; } = string.Empty;
+
+    [CodeMetadata]
+    public string Category { get; set; } = string.Empty;
 
     public string Description { get; set; } = string.Empty;
 
     public CodeType Type { get; set; }
 
     public bool Enabled { get; set; }
+
     public bool Naked { get; set; }
 
     public List<BasicLexer.Token> Header { get; set; } = new List<BasicLexer.Token>();
@@ -369,8 +376,14 @@ public class CSharpCode : ICode
             var localFuncUnit = SyntaxFactoryEx.MethodDeclaration(methodName, "void",
                                SyntaxFactory.Block(SyntaxFactory.ExpressionStatement(SyntaxFactory.InvocationExpression(SyntaxFactory.IdentifierName(staticMethodName)))), "public");
 
+            var metadataJson = JsonSerializer.Serialize(this, new JsonSerializerOptions
+            {
+                TypeInfoResolver = CodeMetadataAttribute.JsonTypeInfoResolver
+            });
+
             classUnit = classUnit
                 .WithMembers(SyntaxFactory.List(globalMembers))
+                .AddMembers(ConstStringFieldDeclaration("__META__", metadataJson))
                 .AddMembers(CodeProvider.LoaderExecutableMethod)
                 .AddMembers(funcUnit, localFuncUnit);
         }
@@ -468,6 +481,24 @@ public class CSharpCode : ICode
             }
 
             return SyntaxFactory.UsingDirective(nameSyntax);
+        }
+
+        FieldDeclarationSyntax ConstStringFieldDeclaration(string name, string value)
+        {
+            return SyntaxFactory.FieldDeclaration
+            (
+                SyntaxFactory.VariableDeclaration(SyntaxFactory.ParseTypeName("string")).AddVariables
+                (
+                    SyntaxFactory.VariableDeclarator(name).WithInitializer
+                    (
+                        SyntaxFactory.EqualsValueClause
+                        (
+                            SyntaxFactory.LiteralExpression(SyntaxKind.StringLiteralExpression, SyntaxFactory.Literal(value))
+                        )
+                    )
+                )
+            )
+            .AddModifiers(SyntaxFactory.Token(SyntaxKind.PublicKeyword), SyntaxFactory.Token(SyntaxKind.ConstKeyword));
         }
     }
 

--- a/Source/Libraries/HedgeModManager.CodeCompiler/CodeMetadataAttribute.cs
+++ b/Source/Libraries/HedgeModManager.CodeCompiler/CodeMetadataAttribute.cs
@@ -1,0 +1,36 @@
+﻿namespace HedgeModManager.CodeCompiler;
+using System.Text.Json.Serialization.Metadata;
+
+[AttributeUsage(AttributeTargets.Property)]
+public class CodeMetadataAttribute : Attribute
+{
+    public static CodeMetadataJsonTypeInfoResolver JsonTypeInfoResolver = new();
+
+    public class CodeMetadataJsonTypeInfoResolver : DefaultJsonTypeInfoResolver
+    {
+        public CodeMetadataJsonTypeInfoResolver()
+        {
+            Modifiers.Add
+            (
+                typeInfo =>
+                {
+                    if (typeInfo.Kind != JsonTypeInfoKind.Object)
+                        return;
+
+                    foreach (var property in typeInfo.Properties)
+                    {
+                        var hasAttribute = property.AttributeProvider?
+                            .GetCustomAttributes(typeof(CodeMetadataAttribute), true)
+                            .Any() ?? false;
+
+                        if (hasAttribute)
+                            continue;
+
+                        // Skip all properties without the CodeMetadata attribute.
+                        property.ShouldSerialize = (obj, value) => false;
+                    }
+                }
+            );
+        }
+    }
+}

--- a/Source/Libraries/HedgeModManager.CodeCompiler/HedgeModManager.CodeCompiler.csproj
+++ b/Source/Libraries/HedgeModManager.CodeCompiler/HedgeModManager.CodeCompiler.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.6.0" />
     <PackageReference Include="Mono.Cecil" Version="0.11.5" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.6.133" PrivateAssets="all" />
+    <PackageReference Include="System.Text.Json" Version="10.0.10" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR exports code metadata to a JSON string accessible via the `__META__` constant in C# codes.

This is intended for use by CommonLoader for populating metadata in the `CodeObject` class, although it may also be accessed by HMM codes if they need it.